### PR TITLE
Include from_email option to send email to user

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -157,3 +157,5 @@ APSCHEDULER_RUN_NOW_TIMEOUT = 25  # Second
 
 # SOTP configuration    
 SOTP_TIME_EXPIRATION = 5 # in minutes
+
+SOTP_FROM_EMAIL = "from@email.com" 

--- a/sotp/services.py
+++ b/sotp/services.py
@@ -53,7 +53,7 @@ class GenerateSOTP:
    
    
     @classmethod
-    def send_otp_email(self, otp_code:int, user_email:str,from_email:str):
+    def send_otp_email(self, otp_code:int, user_email:str):
         """
         > Send an email to the user with the OTP code
         

--- a/sotp/services.py
+++ b/sotp/services.py
@@ -53,7 +53,7 @@ class GenerateSOTP:
    
    
     @classmethod
-    def send_otp_email(self, otp_code:int, user_email:str):
+    def send_otp_email(self, otp_code:int, user_email:str,from_email:str):
         """
         > Send an email to the user with the OTP code
         
@@ -67,7 +67,7 @@ class GenerateSOTP:
         send_mail(
             'Confirm OTP',
             'Use this secured OTP to authenticate your account\nOTP: {}'.format(otp_code),
-            'noreply@abram.tech',
+            settings.SOTP_FROM_EMAIL,
             [user_email],
             fail_silently=False,
         )


### PR DESCRIPTION
I noticed that there was no way to change the default from_email to mine. So I fixed that by creating a global variable in the settings.py file and importing it into the send_otp_email method.